### PR TITLE
Added docker build + docker build and instructions to README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:23.8.0-alpine3.21
+
+WORKDIR /webmixer
+
+COPY . .
+
+RUN apk add git && npm install
+
+ENTRYPOINT [ "node", "." ]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ This project has taken considerable time to create. If you find it useful and wo
 4. Visit the admin URL in your browser to configure the server.
 5. Open the server IP address on another device and start mixing.
 
+## Basic Setup Instructions For Docker
+1. Install Git and Docker 
+
+2. Then execute following commands:
+```
+git clone https://github.com/castles/OSCWebMixer2.git
+
+cd OSCWebMixer2 
+
+docker build -t oscwebmixer2:latest .
+
+docker compose up -d
+```
+
+3. To see logs and to see what address to connect run:
+```
+docker compose logs -f webmixer
+```
+
 ## FAQs
 <details>
   <summary>My External Devices won't connect</summary>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  webmixer:
+    image: oscwebmixer2:latest
+    container_name: webmixer
+    restart: unless-stopped
+    network_mode: host
+    # volumes:  # If initial config is empty, then program not starting correctly
+    #   - ./config.json:/webmixer/config.json


### PR DESCRIPTION
This adds most basic and easy docker setup.

network_mode: host is used because you create ports in webadmin and it is not convinient to change docker setup every time you add new host.

So it can be very easilly be used to quick run webmixer.

Maybe you can modify to add it to hub.docker.com to be easily used by simple docker without docker compose

Only problem that ./config.json (commented out in docker-compose.yaml (to let settings be persistent across reboots)) if program starts  with empty config.json, progam crashes. Maybe add check (if file exists,but json parser fails to parse config,then backup it to config.json.bak and regenerate new config on top of this file.)