### PR TITLE
Set OSC port IP to 0.0.0.0 to listen on all interfaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -637,7 +637,7 @@ function fetchValues()
 function startOSC()
 {
 	udpPort = new osc.UDPPort({
-		localAddress: mixServerIP,
+		localAddress: "0.0.0.0",
 		localPort: config.osc.port
 	});
 


### PR DESCRIPTION
Fixes #9 

Because of the way `os.networkInterfaces()` works, the first network interface of the returned array is not always the host's primary physical interface. 

Setting the listen address of the OSC.js `udpPort` to the IP of this interface can cause the connection to the mixer to fail if the interface is not the correct one, e.g. a virtual network interface (as described by @prochak86).

To let webmixer listen on all interfaces, I changed the `localAddress` of the `udpPort` to 0.0.0.0. This also makes it better to use if the host computer is connected to multiple networks, with only one of them being the console network.